### PR TITLE
Install on kernel 5.10

### DIFF
--- a/README
+++ b/README
@@ -1,5 +1,6 @@
-This is an updated kernel module to fix touchpad detection on the Ideapad S145.
-Builds on ElementaryOS (5.3.x) and probably other
+Fork of https://github.com/Jookia/elan_i2c_dkms,to fix touchpad detection on the Ideapad S145.
+
+Builds on ElementaryOS (5.3.x) and probably other.
 
 To install, run this in a terminal:
 

--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-Fork of https://github.com/Jookia/elan_i2c_dkms,to fix touchpad detection on the Ideapad S145.
+Fork of https://github.com/Jookia/elan_i2c_dkms, to fix touchpad detection on the Ideapad S145.
 
 Builds on ElementaryOS (5.3.x) and probably other.
 

--- a/README
+++ b/README
@@ -1,9 +1,8 @@
-This is an updated kernel module to fix touchpad detection on the Ryzen Ideapad 330.
-Builds on Mint 18 (kernel 4.4) and 19 (kernel 4.15).
+This is an updated kernel module to fix touchpad detection on the Ideapad S145.
+Builds on ElementaryOS (5.3.x) and probably other
 
-To download and install, run this in a terminal:
+To install, run this in a terminal:
 
-git clone https://www.github.com/Jookia/elan_i2c_dkms
 cd elan_i2c_dkms
 sudo dkms install .
 

--- a/dkms.conf
+++ b/dkms.conf
@@ -1,5 +1,5 @@
 PACKAGE_NAME="elan_i2c"
-PACKAGE_VERSION="4.19-rc4-1"
+PACKAGE_VERSION="5.3.x-1"
 BUILT_MODULE_NAME="elan_i2c"
 DEST_MODULE_LOCATION="/kernel/drivers/input/mouse"
 AUTOINSTALL="yes"

--- a/elan_i2c_core.c
+++ b/elan_i2c_core.c
@@ -1265,6 +1265,7 @@ static const struct acpi_device_id elan_acpi_id[] = {
 	{ "ELAN061D", 0 },
 	{ "ELAN061E", 0 },
 	{ "ELAN0622", 0 },
+	{ "ELAN0633", 0 },
 	{ "ELAN1000", 0 },
 	{ }
 };


### PR DESCRIPTION
I have a notebook Lenovo Ideapad s145 with Debian 10 using backport kernel 5.10. I install this module but dont work. How to I can uninstall this module and get a 5.10 version from this module?